### PR TITLE
ci: point cargo jobs at the actual crate directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,20 @@
 name: CI
 on: [push, pull_request]
+
+# This repo is Python at the root; the Rust code lives in two independent
+# crates (there is no root Cargo.toml and no cargo workspace), so every
+# cargo job has to run from inside a crate directory.
 jobs:
   test:
+    name: test (${{ matrix.crate }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [secure_signer, coldstar_zk]
+    defaults:
+      run:
+        working-directory: ${{ matrix.crate }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -10,7 +22,15 @@ jobs:
       - run: cargo test --all-features
       - run: cargo clippy -- -D warnings
   fmt:
+    name: fmt (${{ matrix.crate }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [secure_signer, coldstar_zk]
+    defaults:
+      run:
+        working-directory: ${{ matrix.crate }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
## Failing output before

Every CI run in this repo's history has failed the same way — most recently run
[30591522447](https://github.com/ExpertVagabond/coldstar-colosseum/actions/runs/30591522447)
(2026-07-30, `chore/repo-slim`), and identically on `main` in run
[29794805996](https://github.com/ExpertVagabond/coldstar-colosseum/actions/runs/29794805996):

```
error: `cargo metadata` exited with an error: error: could not find `Cargo.toml` in
`/home/runner/work/coldstar-colosseum/coldstar-colosseum` or any parent directory
```

Reproduced locally from a fresh clone:

```
$ cargo metadata --format-version 1 --no-deps
error: could not find `Cargo.toml` in `.../coldstar-colosseum` or any parent directory
```

Every job died in seconds, before a single line of Rust was read.

## Root cause

The workflow ran `cargo build` / `cargo test` / `cargo clippy` / `cargo fmt` from the
repository root. There is no root `Cargo.toml` and no cargo workspace. The root is the
Python project (`main.py`, `pyproject.toml`, the TUI/CLI); the Rust code lives in two
independent crates:

- `secure_signer/` — `coldstar_secure_signer` v1.1.0
- `coldstar_zk/` — `coldstar_zk` v0.1.0

Neither was referenced by the workflow. This is **not** fallout from the repo-slim work:
`git log --all --diff-filter=D -- Cargo.toml` returns nothing (a root manifest never
existed), and the workflow has failed on every run since it was added in `961040f`.
`main` and `chore/repo-slim` currently have identical trees, so both branches are
affected equally.

## What changed

`.github/workflows/ci.yml`, and nothing else. Both jobs — not just `fmt` — carried the
same wrong assumption, so both were fixed:

- `test` (build + test + clippy) and `fmt` each become a 2-way matrix over
  `[secure_signer, coldstar_zk]`, with `defaults.run.working-directory: ${{ matrix.crate }}`.
- Cargo commands and flags are unchanged, as are the toolchain pins (`stable` for test,
  `nightly` + rustfmt for fmt).
- `fail-fast: false`, so one crate failing does not hide the other crate's result.
- No source files touched, no root `Cargo.toml` added, no cargo workspace introduced.

## Verification

Run [31417072267](https://github.com/ExpertVagabond/coldstar-colosseum/actions/runs/31417072267)
on this branch. The `cargo metadata` error is gone and the jobs now execute real work:

| Job | Result |
|---|---|
| `test (secure_signer)` | **success** — build ok, `15 passed; 0 failed` + `1 passed`, `clippy -D warnings` clean |
| `test (coldstar_zk)` | build ok, `47 passed; 0 failed`, then **clippy fails** (8 errors) |
| `fmt (secure_signer)` | **fails** — rustfmt drift, 19 hunks across 4 files |
| `fmt (coldstar_zk)` | **fails** — rustfmt drift, 26 hunks across 10 files |

## Known follow-ups (deliberately not fixed here)

Correcting the paths exposes two pre-existing problems that the manifest error had been
masking. Both require editing Rust source, which does not belong in a CI-config PR:

1. **rustfmt drift** in both crates (`secure_signer/src/{crypto,lib,main,secure_buffer}.rs`,
   `coldstar_zk/src/{binding,commitment,error,ffi,policy,transcript,types,proofs/*}.rs`).
   A standalone `cargo fmt` pass fixes it.
2. **8 clippy errors in `coldstar_zk`**: 5× `unsafe function's docs are missing a
   `# Safety` section` (FFI surface), plus `doc list item without indentation`,
   `redundant reference in writeln! argument`, and a `to_*`-takes-`self`-by-value lint.
   The `# Safety` ones are worth a real look given this is the ZK/FFI boundary.

Making the jobs green by pointing them at nothing would be worse than a red build, so the
paths point at the real crates and the remaining failures stay visible.

## Risk

Low. CI configuration only — no application code, build output, or published artifact is
affected. Worst case is that CI now reports failures that were always present but hidden.
